### PR TITLE
admin type fix for sign up

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     # For additional fields in app/views/devise/registrations/new.html.erb
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name, :user_type])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name, :admin])
 
     # For additional in app/views/devise/registrations/edit.html.erb
     devise_parameter_sanitizer.permit(:account_update, keys: [:username])

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  # validates :admin, presence: true
+  validates :admin, inclusion: { in: %w[Y N] }
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -1,5 +1,5 @@
 class UserGroup < ApplicationRecord
-  validates :role, inclusion: { in: %w(R M), message: 'Doit être Référent ou membre' }
+  validates :role, inclusion: { in: %w[R M], message: 'Doit être Référent ou membre' }
   belongs_to :user
   belongs_to :group
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -54,6 +54,6 @@ class ApplicationPolicy
   end
 
   def admin?
-    user.admin == true
+    user.admin == 'Y'
   end
 end

--- a/app/views/admin_users/_form.html.erb
+++ b/app/views/admin_users/_form.html.erb
@@ -1,6 +1,6 @@
 <%= simple_form_for :admin_user, url: admin_users_path do |f| %>
   <%= f.input :email %>
-  <%= f.input :admin, :as => :hidden, :input_html => { :value => false }%>
+  <%= f.input :admin, :as => :hidden, :input_html => { :value => 'N' }%>
   <%= f.input :password, :as => :hidden, :input_html => { :value => @pwd }%>
   <%= f.input :groups, as: :select, collection: Group.where(user: current_user), selected: 1, label: 'Groupe' %>
   <%= f.input :role, as: :select, collection: {"Membre": "M", "Référent": "R"}, selected: 1, label: 'Role' %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -16,7 +16,7 @@
                 required: true,
                 autofocus: true,
                 input_html: { autocomplete: "last-name" }%>
-    <%= f.input :admin, :as => :hidden, :input_html => { :value => true }%>
+    <%= f.input :admin, :as => :hidden, :input_html => { value: 'Y' }%>
     <%= f.input :password,
                 required: true,
                 hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),

--- a/db/migrate/20210206163052_change_admin_type_to_user.rb
+++ b/db/migrate/20210206163052_change_admin_type_to_user.rb
@@ -1,0 +1,7 @@
+class ChangeAdminTypeToUser < ActiveRecord::Migration[6.0]
+  def change
+    change_table :users do |t|
+      t.change :admin, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_06_154136) do
+ActiveRecord::Schema.define(version: 2021_02_06_163052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -112,7 +112,7 @@ ActiveRecord::Schema.define(version: 2021_02_06_154136) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "first_name"
     t.string "last_name"
-    t.boolean "admin"
+    t.string "admin"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
correction pour un type admin au sign up

J'ai finalement opté pour une string pour admin car en fait on ne peux pas gérer une sting en hiden field d'un form et on ne paux pas réécrire les controllers de devise donc plus simple à gérer. 

admin = "Y" si c'est un admin, 'N' sinon 